### PR TITLE
Fix php warning

### DIFF
--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -228,8 +228,10 @@ function simcal_get_calendars( $exclude = '', $cached = true ) {
 		// Exclude grouped calendars
 		foreach ($calendars as $key => $value) {
 			$meta_calendarGrouped = get_post_meta($key,'_grouped_calendars_ids');
-			if( $meta_calendarGrouped[0] != '' ){
-				unset($calendars[$key]);
+			if( isset($meta_calendarGrouped[0]) ){
+				if( $meta_calendarGrouped[0] != '' ){
+					unset($calendars[$key]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Comprovar l'existència d'una variable per evitar un warning de php.

Proves:

- Cal anar a l'edició d'un calendari del simple calendar amb la variable `debug` activada i comprovar que no apareix cap notificació.
- Cal anar una pagina on és tingui afegit un giny del simple calendar i comprovar que no apareix cap notificació.
- Cal anar a modificar un giny del simple calendar al personalitza i comprovar que no apareix cap notificació.