### PR TITLE
Wip fix private password calendar

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -243,6 +243,13 @@ class Post_Types {
 				if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 					return '';
 				} else {
+
+					// XTEC ************ AFEGIT - Add private and protected post option
+					// 2017.03.06 @xaviernietosanchez
+					if ( post_password_required( $post ) )
+						return get_the_password_form( $post );
+					// ************ FI
+
 					ob_start();
 					simcal_print_calendar( $post );
 					return ob_get_clean();

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -88,7 +88,23 @@ class Calendar extends \WP_Widget implements Widget {
 
 		$id = isset( $instance['calendar_id'] ) ? absint( $instance['calendar_id'] ) : 0;
 		if ( $id > 0 ) {
+
+			// XTEC ************ AFEGIT - Check if is a private calendar or protected with password
+			// 2017.03.07 @xaviernietosanchez
+			if ( get_post_status( $id ) !== 'private' ){
+				if ( post_password_required( $id ) ){
+					echo get_the_password_form( $id );
+				} else {
+			// ************ FI
+
 			simcal_print_calendar( $id );
+
+			// XTEC ************ AFEGIT - Check if is a private calendar or protected with password
+			// 2017.03.07 @xaviernietosanchez
+			 	}
+			}
+			// ************ FI
+
 		}
 
 		echo $args['after_widget'];


### PR DESCRIPTION
Aplicades modificacions per permetre calendaris privats i protegits amb contrasenya.
El comportem ara és:

**Calendari Públic:**
- Widget i  Pàgina: Es visualitza com fins ara

**Calendari protegit amb contrasenya:**
- Widget: Surt un formulari per introduir-hi la contrasenya a l'espai on hauria de mostrar el calendari. Una vegada introduida la contrasenya es recarrega la pàgina i si la contrasenya es correcta mostra el calendari
- Pàgina: Surt un formulari per introduir-hi la contrasenya. Una vegada introduida la contrasenya es recarrega la pàgina i si la contrasenya es correcta mostra el calendari.

**Calendari Privat:**
- Widget: No es mostra si ja esta afegit al widget, i tampoc permet seleccionar-ho per mostrar-ho
- Pàgina: Indica que no s'ha trobat el contingut.

Proves:

- Cal crear un calendari i assignar-li un Identificador de calendari de Google.
- Canviar a les diferents visibilitats del calendari (públic, protegit amb contrasenya i privat) i comprovar el seu comportament com a giny i com a pàgina.